### PR TITLE
Cache by vector count instead of centroid count

### DIFF
--- a/index.py
+++ b/index.py
@@ -37,16 +37,16 @@ class Index:
 
     def simulate_queries(self, cache_size, nprobe):
         idx_cache = [] # index 0 is the MRU centroid
-        num_disk_reads = 0
-        n_points_read = 0
+        n_disk_reads = 0
+        n_vectors_read_from_disk = 0
         centroid_idxs = self.find_nearest_centroids(nprobe).flatten()
         list_sizes = self.get_list_sizes()
         for centroid in centroid_idxs:
             if centroid in idx_cache: # cluster is in cache
                 idx_cache.remove(centroid)
             else:
-                num_disk_reads += 1
-                n_points_read += list_sizes[centroid]
+                n_disk_reads += 1
+                n_vectors_read_from_disk += list_sizes[centroid]
 
             # insert this centroid at front of list
             idx_cache.insert(0, centroid) 
@@ -58,14 +58,14 @@ class Index:
                 popped = idx_cache.pop()
                 print(f'Evicting centroid {popped} from cache')
 
-        cache_hits = len(centroid_idxs) - num_disk_reads
+        cache_hits = len(centroid_idxs) - n_disk_reads
         unique_centroids_accessed = Counter(centroid_idxs).keys()
         
-        unique_points_read = sum([list_sizes[x] for x in unique_centroids_accessed])
+        unique_vectors_read = sum([list_sizes[x] for x in unique_centroids_accessed])
         print('Simulation results:')
         print(f'\t{cache_hits} cache hits')
-        print(f'\t{num_disk_reads} disk reads ({len(unique_centroids_accessed)} unavoidable)')
-        print(f'\t{n_points_read} vectors read from disk ({unique_points_read} unavoidable)')
+        print(f'\t{n_disk_reads} disk reads ({len(unique_centroids_accessed)} unavoidable)')
+        print(f'\t{n_vectors_read_from_disk} vectors read from disk ({unique_vectors_read} unavoidable)')
    
     def get_list_sizes(self):
         invlists = self.index_ivf.invlists

--- a/index.py
+++ b/index.py
@@ -1,6 +1,7 @@
 import faiss
 import os
 from collections import Counter
+import numpy as np
 
 class Index:
 
@@ -24,18 +25,66 @@ class Index:
         self.xq = xq
         self.gt = gt
 
+    def search(self, nprobe):
+        self.index_ivf.nprobe = nprobe
+        _, I = self.index_ivf.search(self.xq, k=1)
+        labels = I[:, :1]
+        # print(f'labels: {labels.size} - {np.min(labels)} -> {np.max(labels)}')
+        return labels
+
+    # returns the closest centroid for each query vector
+    def search_centroid(self):
+        n = len(self.xq)
+        centroid_ids = np.full(n, fill_value=-1, dtype=np.int64)
+        faiss.search_centroid(
+            self.index_ivf, 
+            faiss.swig_ptr(self.xq),
+            n,
+            faiss.swig_ptr(centroid_ids)
+        )
+        return centroid_ids
+
+    def search_and_return_centroids(self, nprobe):
+        self.index_ivf.nprobe = nprobe # how many clusters to search
+        n = len(self.xq)
+        k = 1
+        distances = np.full(n * k, fill_value=-1, dtype=np.float32)
+        labels = np.full(n, fill_value=-1, dtype=np.int64)
+        query_centroid_ids = np.full(n, fill_value=-1, dtype=np.int64)
+        result_centroid_ids = np.full(n * k, fill_value=-1, dtype=np.int64)
+
+        faiss.search_and_return_centroids(
+            self.index_ivf, 
+            n, # number of query vectors
+            faiss.swig_ptr(self.xq), # query vectors
+            k, # num of nearest neighbors to get
+            faiss.swig_ptr(distances), # distance to each of the result centroids
+            faiss.swig_ptr(labels),
+            faiss.swig_ptr(query_centroid_ids), # centroid ids corresponding to the query vectors (size n)
+            faiss.swig_ptr(result_centroid_ids), # centroid ids corresponding to the results (size n * k)
+        )
+        # print(f'query_centroid_ids: {query_centroid_ids.shape} - {np.min(query_centroid_ids)} -> {np.max(query_centroid_ids)}')
+        # print(f'result_centroid_ids: {result_centroid_ids.shape} - {np.min(result_centroid_ids)} -> {np.max(result_centroid_ids)}')
+        # print(f'labels: {labels.shape} - {np.min(labels)} -> {np.max(labels)}')
+        return query_centroid_ids, result_centroid_ids, labels
+    
+    def get_list_sizes(self):
+        invlists = self.index_ivf.invlists
+        d = {}
+        for i in range(invlists.nlist):
+            d[i] = invlists.list_size(i)
+        return d
+    
+    def report_recall(self, ids):
+        recall_at_1 = (ids == self.gt[:, :1]).sum() / float(self.xq.shape[0])
+        print("recall@1: %.3f" % recall_at_1)
+
     def find_nearest_centroids(self, k):
         centroids = self.index.quantizer.reconstruct_n(0, self.index.nlist)
         _, centroid_idxs = faiss.knn(self.xq, centroids, k)
         return centroid_idxs
-
-    def search_and_report_recall(self, nprobe):
-        self.index.nprobe = nprobe
-        _, I = self.index_ivf.search(self.xq, 1)
-        recall_at_1 = (I[:, :1] == self.gt[:, :1]).sum() / float(self.xq.shape[0])
-        print("recall@1: %.3f" % recall_at_1)
-
-    def simulate_queries(self, cache_size, nprobe):
+    
+    def simulate_cache(self, cache_size, nprobe):
         idx_cache = [] # index 0 is the MRU centroid
         n_disk_reads = 0
         n_vectors_read_from_disk = 0
@@ -56,21 +105,12 @@ class Index:
 
             if new_cache_size > cache_size: # over cache size limit
                 popped = idx_cache.pop()
-                print(f'Evicting centroid {popped} from cache')
 
         cache_hits = len(centroid_idxs) - n_disk_reads
         unique_centroids_accessed = Counter(centroid_idxs).keys()
         
         unique_vectors_read = sum([list_sizes[x] for x in unique_centroids_accessed])
-        print('Simulation results:')
+        print('Old (correct?) simulation results:')
         print(f'\t{cache_hits} cache hits')
         print(f'\t{n_disk_reads} disk reads ({len(unique_centroids_accessed)} unavoidable)')
         print(f'\t{n_vectors_read_from_disk} vectors read from disk ({unique_vectors_read} unavoidable)')
-   
-    def get_list_sizes(self):
-        invlists = self.index_ivf.invlists
-        d = {}
-        for i in range(invlists.nlist):
-            d[i] = invlists.list_size(i)
-        return d
-        

--- a/main.py
+++ b/main.py
@@ -13,11 +13,20 @@ def main():
     xq = utils.fvecs_read("sift/sift_query.fvecs")
     gt = utils.ivecs_read("sift/sift_groundtruth.ivecs")
     ind = index.Index("IVF4096,Flat", xt, xb, xq, gt)
-    
-    # cache_size is in "number of vectors"
-    ind.simulate_queries(cache_size=100000, nprobe=16)
 
-    ind.search_and_report_recall(nprobe=16)
+    nprobe = 16
+    cache_size = 100000
+
+    # cache_size is in "number of vectors"
+    ind.simulate_cache(cache_size=cache_size, nprobe=nprobe)
+
+    print("search_and_return_centroids...")
+    _query_centroid_ids, _result_centroid_ids, labels = ind.search_and_return_centroids(nprobe=nprobe)
+    ind.report_recall(labels)
+
+    print("standard search...")
+    labels = ind.search(nprobe=nprobe)
+    ind.report_recall(labels)
 
 
     print("done")

--- a/main.py
+++ b/main.py
@@ -14,9 +14,13 @@ def main():
     gt = utils.ivecs_read("sift/sift_groundtruth.ivecs")
     ind = index.Index("IVF4096,Flat", xt, xb, xq, gt)
     
-    ind.simulate_queries(cache_size=2048, nprobe=16)
+    # cache_size is in "number of vectors"
+    ind.simulate_queries(cache_size=100000, nprobe=16)
 
     ind.search_and_report_recall(nprobe=16)
+
+
+    print("done")
     
     
 


### PR DESCRIPTION
Modifies the cache to have a size limit based on the number of vectors stored (instead of number of centroids stored).  Uses the [`OnDiskInvertedLists`](https://faiss.ai/cpp_api/struct/structfaiss_1_1OnDiskInvertedLists.html) member of our index to get the size of each inverted list (thus the size of each cluster).