### PR TITLE
Add cache index to results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,10 @@ cython_debug/
 *.tar.gz
 indexes/
 sift/
+glove-25-angular.hdf5
+indexes
+nprobe_cache.json
+results.csv
+glove-200-angular.hdf5
+results*.csv
+.vscode/launch.json

--- a/cache.py
+++ b/cache.py
@@ -208,14 +208,15 @@ class RandomCache(Cache):
             self.vectors_read += self.list_sizes[cid]
             
         # if cache will be too big keep trimming fat until we are under capacity
-        while self.size + self.list_sizes[cid] > self.capacity:
-            ind_to_remove = random.randrange(len(self.centroids))
-            self.size -= self.list_sizes[self.centroids[ind_to_remove]]
-            self.centroids = np.delete(self.centroids, ind_to_remove)
+        if self.capacity > 0:
+            while self.size + self.list_sizes[cid] > self.capacity:
+                ind_to_remove = random.randrange(len(self.centroids))
+                self.size -= self.list_sizes[self.centroids[ind_to_remove]]
+                self.centroids = np.delete(self.centroids, ind_to_remove)
             
-        # insert cid at the front of cache
-        self.centroids = np.insert(self.centroids, 0, cid)
-        self.size += self.list_sizes[cid]
+            # insert cid at the front of cache
+            self.centroids = np.insert(self.centroids, 0, cid)
+            self.size += self.list_sizes[cid]
     
     def get_capacity(self) -> int:
         return self.capacity

--- a/main.py
+++ b/main.py
@@ -1,33 +1,180 @@
 import utils
 import index
-from cache import LRUCache, PinCache
+from cache import LRUCache, PinCache, RandomCache
 import numpy as np
 from test_runner import TestRunner
 
 def main():
     matrix = {
-        'sift': {
-            'n_clusters': [2048, 4096],
-            'caches': [
-                LRUCache(capacity=50000),
-                LRUCache(capacity=100000),
-                PinCache(capacity=100000, pincount=5)
-            ]
-        },
-        # 'glove-50': {
-        #     'n_clusters': [64, 128],
+        # 'sift': {
+        #     'n_clusters': [2048, 4096],
         #     'caches': [
-        #         LRUCache(capacity=100000),
+        #         LRUCache(capacity=50000),
         #         PinCache(capacity=100000, pincount=5)
         #     ]
         # },
-        # 'glove-100': {
-        #     'n_clusters': [2048, 4096],
+        # 'sift': {
+        #     'n_clusters': [2048, 4096, 8192, 16384, 32768, 65536, 131072],
         #     'caches': [
+        #         LRUCache(capacity=0),
+        #         LRUCache(capacity=10000),
+        #         LRUCache(capacity=50000),
         #         LRUCache(capacity=100000),
-        #         PinCache(capacity=100000, pincount=5)
+        #         LRUCache(capacity=200000),
+        #         LRUCache(capacity=500000),
+        #         LRUCache(capacity=1000000),
+        #         RandomCache(capacity=0),
+        #         RandomCache(capacity=10000),
+        #         RandomCache(capacity=50000),
+        #         RandomCache(capacity=100000),
+        #         RandomCache(capacity=200000),
+        #         RandomCache(capacity=500000),
+        #         RandomCache(capacity=1000000),
         #     ]
-        # }
+        # },
+        # 'glove-25': {
+        #     'n_clusters': [2048, 4096, 8192, 16384, 32768, 65536, 131072],
+        #     'caches': [
+        #         LRUCache(capacity=0),
+        #         LRUCache(capacity=10000),
+        #         LRUCache(capacity=50000),
+        #         LRUCache(capacity=100000),
+        #         LRUCache(capacity=200000),
+        #         LRUCache(capacity=500000),
+        #         LRUCache(capacity=1000000),
+        #         RandomCache(capacity=0),
+        #         RandomCache(capacity=10000),
+        #         RandomCache(capacity=50000),
+        #         RandomCache(capacity=100000),
+        #         RandomCache(capacity=200000),
+        #         RandomCache(capacity=500000),
+        #         RandomCache(capacity=1000000),
+        #     ]
+        # },
+        # 'glove-200': {
+        #     'n_clusters': [2048, 4096, 8192, 16384, 32768, 65536, 131072],
+        #     'caches': [
+        #         LRUCache(capacity=0),
+        #         LRUCache(capacity=10000),
+        #         LRUCache(capacity=50000),
+        #         LRUCache(capacity=100000),
+        #         LRUCache(capacity=200000),
+        #         LRUCache(capacity=500000),
+        #         LRUCache(capacity=1000000),
+        #         RandomCache(capacity=0),
+        #         RandomCache(capacity=10000),
+        #         RandomCache(capacity=50000),
+        #         RandomCache(capacity=100000),
+        #         RandomCache(capacity=200000),
+        #         RandomCache(capacity=500000),
+        #         RandomCache(capacity=1000000),
+        #     ]
+        # },
+        # 'sift': {
+        #     'n_clusters': [131072],
+        #     'caches': [
+        #         PinCache(capacity=10000, pincount=0),
+        #         PinCache(capacity=10000, pincount=50),
+        #         PinCache(capacity=10000, pincount=100),
+        #         PinCache(capacity=10000, pincount=150),
+        #         PinCache(capacity=10000, pincount=200),
+        #         PinCache(capacity=100000, pincount=0),
+        #         PinCache(capacity=100000, pincount=500),
+        #         PinCache(capacity=100000, pincount=1000),
+        #         PinCache(capacity=100000, pincount=1500),
+        #         PinCache(capacity=100000, pincount=2000),
+        #         PinCache(capacity=200000, pincount=0),
+        #         PinCache(capacity=200000, pincount=1000),
+        #         PinCache(capacity=200000, pincount=2000),
+        #         PinCache(capacity=200000, pincount=3000),
+        #         PinCache(capacity=200000, pincount=4000),
+        #         PinCache(capacity=500000, pincount=0),
+        #         PinCache(capacity=500000, pincount=2500),
+        #         PinCache(capacity=500000, pincount=5000),
+        #         PinCache(capacity=500000, pincount=7500),
+        #         PinCache(capacity=500000, pincount=10000),
+        #     ]
+        # },
+        # 'glove-25': {
+        #     'n_clusters': [131072],
+        #     'caches': [
+        #         PinCache(capacity=10000, pincount=0),
+        #         PinCache(capacity=10000, pincount=50),
+        #         PinCache(capacity=10000, pincount=100),
+        #         PinCache(capacity=10000, pincount=150),
+        #         PinCache(capacity=10000, pincount=200),
+        #         PinCache(capacity=100000, pincount=0),
+        #         PinCache(capacity=100000, pincount=500),
+        #         PinCache(capacity=100000, pincount=1000),
+        #         PinCache(capacity=100000, pincount=1500),
+        #         PinCache(capacity=100000, pincount=2000),
+        #         PinCache(capacity=200000, pincount=0),
+        #         PinCache(capacity=200000, pincount=1000),
+        #         PinCache(capacity=200000, pincount=2000),
+        #         PinCache(capacity=200000, pincount=3000),
+        #         PinCache(capacity=200000, pincount=4000),
+        #         PinCache(capacity=500000, pincount=0),
+        #         PinCache(capacity=500000, pincount=2500),
+        #         PinCache(capacity=500000, pincount=5000),
+        #         PinCache(capacity=500000, pincount=7500),
+        #         PinCache(capacity=500000, pincount=10000),
+        #     ]
+        # },
+        # 'glove-200': {
+        #     'n_clusters': [131072],
+        #     'caches': [
+        #         # PinCache(capacity=10000, pincount=0),
+        #         # PinCache(capacity=10000, pincount=25),
+        #         # PinCache(capacity=10000, pincount=50),
+        #         PinCache(capacity=10000, pincount=75),
+        #         PinCache(capacity=10000, pincount=100),
+        #         PinCache(capacity=100000, pincount=0),
+        #         PinCache(capacity=100000, pincount=250),
+        #         PinCache(capacity=100000, pincount=500),
+        #         PinCache(capacity=100000, pincount=750),
+        #         PinCache(capacity=100000, pincount=1000),
+        #         PinCache(capacity=200000, pincount=0),
+        #         PinCache(capacity=200000, pincount=500),
+        #         PinCache(capacity=200000, pincount=1000),
+        #         PinCache(capacity=200000, pincount=1500),
+        #         PinCache(capacity=200000, pincount=2000),
+        #         PinCache(capacity=500000, pincount=0),
+        #         PinCache(capacity=500000, pincount=1250),
+        #         PinCache(capacity=500000, pincount=2500),
+        #         PinCache(capacity=500000, pincount=3750),
+        #         PinCache(capacity=500000, pincount=5000),
+        #     ]
+        # },
+        'sift': {
+            'n_clusters': [131072],
+            'caches': [
+                PinCache(capacity=500000, pincount=0),
+                PinCache(capacity=500000, pincount=2500),
+                PinCache(capacity=500000, pincount=5000),
+                PinCache(capacity=500000, pincount=7500),
+                PinCache(capacity=500000, pincount=10000),
+            ]
+        },
+        'glove-25': {
+            'n_clusters': [131072],
+            'caches': [
+                PinCache(capacity=500000, pincount=0),
+                PinCache(capacity=500000, pincount=2500),
+                PinCache(capacity=500000, pincount=5000),
+                PinCache(capacity=500000, pincount=7500),
+                PinCache(capacity=500000, pincount=10000),
+            ]
+        },
+        'glove-200': {
+            'n_clusters': [131072],
+            'caches': [
+                PinCache(capacity=500000, pincount=0),
+                PinCache(capacity=500000, pincount=1250),
+                PinCache(capacity=500000, pincount=2500),
+                PinCache(capacity=500000, pincount=3750),
+                PinCache(capacity=500000, pincount=5000),
+            ]
+        },
     }
     
     runner = TestRunner(matrix, recall_target=0.9)

--- a/main.py
+++ b/main.py
@@ -32,7 +32,7 @@ def main():
     
     runner = TestRunner(matrix, recall_target=0.9)
     runner.run_testing_matrix()
-    runner.write_results('results.csv')
+    # runner.write_results('results.csv')
 
     print("Done")
     

--- a/test_runner.py
+++ b/test_runner.py
@@ -63,6 +63,22 @@ class TestRunner():
             json.dump(self.nprobe_cache, f)
     
     def run_testing_matrix(self):
+        self.filename = f'results{start_time}.csv'
+        with open(self.filename, 'a', newline='') as csvfile:
+            writer = csv.writer(csvfile)
+            writer.writerow([
+                'dataset',
+                'index_description',
+                'cache_description',
+                'hits', 
+                'misses', 
+                'vectors_read', 
+                'num_necessary_cluster_reads',
+                'num_necessary_vector_reads',
+                'recall',
+                'nprobe'
+            ])
+
         for dataset in self.matrix.keys():
             submatrix = self.matrix[dataset]
             for cluster_size in submatrix['n_clusters']:
@@ -100,7 +116,9 @@ class TestRunner():
                 recall=recall,
                 nprobe=nprobe
                 )
-            self.results.append(result)
+            with open(self.filename, 'a', newline='') as csvfile:
+                writer = csv.writer(csvfile)
+                writer.writerow(result.to_row())
         except:
             print("Exception occured in simulation, likely due to pincount")
             result = Result(ind.index_type, cache.to_string(), 0, 0, 0, 0, 0, 0, 0)


### PR DESCRIPTION
This adds a few columns to the results that I used in my data (centroid count, pin count, cache size). Also added all my random test cases to main (mostly commented out) - think that will be helpful if we need to re-run anything. Plus making cache work if its size is 0 (for baselines).